### PR TITLE
Removed malware link from README; guess the domain expired

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -14,9 +14,5 @@
   and you should consider doing that as well. Read the build scripts to see how
   I compile TCHunt.
 
-* Visit the TCHunt homepage for more details:
-
-   http://16s.us/TCHunt/
-
 END
 


### PR DESCRIPTION
The project description in GitHub includes the same malware link, too.